### PR TITLE
add tags support to amazon builders

### DIFF
--- a/app/raw_template_builders.go
+++ b/app/raw_template_builders.go
@@ -220,7 +220,6 @@ func (b *builder) settingsToMap(r *rawTemplate) map[string]interface{} {
 //   device_path              string
 //   enhanced_networking      bool
 //   mount_path               string
-// Not implemented configuration options:
 //   tags                     object of key/value strings
 func (r *rawTemplate) createAmazonChroot() (settings map[string]interface{}, err error) {
 	_, ok := r.Builders[AmazonChroot.String()]
@@ -292,6 +291,9 @@ func (r *rawTemplate) createAmazonChroot() (settings map[string]interface{}, err
 			}
 			continue
 		}
+		if name == "tags" {
+			settings[name] = val
+		}
 	}
 	return settings, nil
 }
@@ -329,6 +331,7 @@ func (r *rawTemplate) createAmazonChroot() (settings map[string]interface{}, err
 //   ssh_private_ip                bool
 //   ssh_timeout                   string
 //   subnet_id                     string
+//   tags                          object of key/value strings
 //   temporary_key_pair_name       string
 //   token                         string
 //   user_data                     string
@@ -338,7 +341,7 @@ func (r *rawTemplate) createAmazonChroot() (settings map[string]interface{}, err
 //   ami_block_device_mappings     array of block device mappings
 //   launch_block_device_mappings  array of block device mappings
 //   run_tags                      object of key/value strings
-//   tags                          object of key/value strings
+
 func (r *rawTemplate) createAmazonEBS() (settings map[string]interface{}, err error) {
 	_, ok := r.Builders[AmazonEBS.String()]
 	if !ok {
@@ -444,6 +447,9 @@ func (r *rawTemplate) createAmazonEBS() (settings map[string]interface{}, err er
 			}
 			continue
 		}
+		if name == "tags" {
+			settings[name] = val
+		}
 	}
 	return settings, nil
 }
@@ -489,6 +495,7 @@ func (r *rawTemplate) createAmazonEBS() (settings map[string]interface{}, err er
 //   ssh_private_ip                bool
 //   ssh_timeout                   string
 //   subnet_id                     string
+//   tags                          object of key/value strings
 //   temporary_key_pair_name       string
 //   user_data                     string
 //   user_data_file                string
@@ -498,7 +505,6 @@ func (r *rawTemplate) createAmazonEBS() (settings map[string]interface{}, err er
 //   ami_block_device_mappings     array of block device mappings
 //   launch_block_device_mappings  array of block device mappings
 //   run_tags                      object of key/value strings
-//   tags                          object of key/value strings
 func (r *rawTemplate) createAmazonInstance() (settings map[string]interface{}, err error) {
 	_, ok := r.Builders[AmazonEBS.String()]
 	if !ok {
@@ -639,6 +645,9 @@ func (r *rawTemplate) createAmazonInstance() (settings map[string]interface{}, e
 				settings[name] = array
 			}
 			continue
+		}
+		if name == "tags" {
+			settings[name] = val
 		}
 	}
 	return settings, nil

--- a/app/raw_template_builders_test.go
+++ b/app/raw_template_builders_test.go
@@ -336,6 +336,10 @@ var testAllBuilders = &rawTemplate{
 						"copy_files": []string{
 							"/etc/resolv.conf",
 						},
+						"tags": map[string]string{
+							"OS_Version": "Ubuntu",
+							"Release":    "Latest",
+						},
 					},
 				},
 			},
@@ -378,6 +382,10 @@ var testAllBuilders = &rawTemplate{
 						},
 						"security_group_ids": []string{
 							"SECURITY_GROUP",
+						},
+						"tags": map[string]string{
+							"OS_Version": "Ubuntu",
+							"Release":    "Latest",
 						},
 					},
 				},
@@ -431,6 +439,10 @@ var testAllBuilders = &rawTemplate{
 						},
 						"security_group_ids": []string{
 							"SECURITY_GROUP",
+						},
+						"tags": map[string]string{
+							"OS_Version": "Ubuntu",
+							"Release":    "Latest",
 						},
 					},
 				},
@@ -1234,7 +1246,11 @@ func TestCreateAmazonChroot(t *testing.T) {
 		"mount_path":          "packer-amazon-chroot-volumes/{{.Device}}",
 		"secret_key":          "AWS_SECRET_ACCESS_KEY",
 		"source_ami":          "SOURCE_AMI",
-		"type":                "amazon-chroot",
+		"tags": map[string]string{
+			"OS_Version": "Ubuntu",
+			"Release":    "Latest",
+		},
+		"type": "amazon-chroot",
 	}
 	bldr, err := testAllBuilders.createAmazonChroot()
 	if err != nil {
@@ -1278,6 +1294,10 @@ func TestCreateAmazonEBS(t *testing.T) {
 		"ssh_username":            "vagrant",
 		"ssh_private_key_file":    "myKey",
 		"ssh_timeout":             "30m",
+		"tags": map[string]string{
+			"OS_Version": "Ubuntu",
+			"Release":    "Latest",
+		},
 		"temporary_key_pair_name": "TMP_KEYPAIR",
 		"token":                   "AWS_SECURITY_TOKEN",
 		"type":                    "amazon-ebs",
@@ -1338,14 +1358,18 @@ func TestCreateAmazonInstance(t *testing.T) {
 		"ssh_timeout":             "30m",
 		"subnet_id":               "subnet-12345def",
 		"temporary_key_pair_name": "TMP_KEYPAIR",
-		"token":                   "AWS_SECURITY_TOKEN",
-		"type":                    "amazon-instance",
-		"user_data":               "SOME_USER_DATA",
-		"user_data_file":          "amazon-instance/amazon.userdata",
-		"vpc_id":                  "VPC_ID",
-		"x509_cert_path":          "/path/to/x509/cert",
-		"x509_key_path":           "/path/to/x509/key",
-		"x509_upload_path":        "/etc/x509",
+		"tags": map[string]string{
+			"OS_Version": "Ubuntu",
+			"Release":    "Latest",
+		},
+		"token":            "AWS_SECURITY_TOKEN",
+		"type":             "amazon-instance",
+		"user_data":        "SOME_USER_DATA",
+		"user_data_file":   "amazon-instance/amazon.userdata",
+		"vpc_id":           "VPC_ID",
+		"x509_cert_path":   "/path/to/x509/cert",
+		"x509_key_path":    "/path/to/x509/key",
+		"x509_upload_path": "/etc/x509",
 	}
 	bldr, err := testAllBuilders.createAmazonInstance()
 	if err != nil {


### PR DESCRIPTION
Adds tag support to amazon-chroot, amazon-ebs, and amazon-instance builders. The tags are added as key:value string pairs within the "tags" array.